### PR TITLE
Add feature to only look at future results (when using streams)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main
+  pull_request_review:
+    types:
+      - submitted
 
 jobs:
   integration-tests:
+    if: ${{ github.ref == 'refs/heads/main' || github.event.review.state == 'approved' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -1,6 +1,8 @@
 name: Run
 
-on: push
+on:
+  - push
+  - pull_request
 
 jobs:
   lint:

--- a/pylemmy/models/comment.py
+++ b/pylemmy/models/comment.py
@@ -95,4 +95,6 @@ class Comment:
         result = self.lemmy.post_request(LemmyAPI.CreateCommentReport, params=payload)
 
         parsed_result = api.comment.CommentReportResponse(**result)
-        return CommentReport(lemmy=self.lemmy, report=parsed_result.comment_report_view, comment=self)
+        return CommentReport(
+            lemmy=self.lemmy, report=parsed_result.comment_report_view, comment=self
+        )

--- a/pylemmy/models/post.py
+++ b/pylemmy/models/post.py
@@ -116,12 +116,11 @@ class Post:
         :param reason: A reason for the report.
         """
         payload = api.post.CreatePostReport(
-            auth=self.lemmy.get_token(),
-            post_id=self.post_view.post.id,
-            reason=reason
+            auth=self.lemmy.get_token(), post_id=self.post_view.post.id, reason=reason
         )
         result = self.lemmy.post_request(LemmyAPI.CreatePostReport, params=payload)
 
         parsed_result = api.post.PostReportResponse(**result)
-        return PostReport(lemmy=self.lemmy, report=parsed_result.post_report_view, post=self)
-
+        return PostReport(
+            lemmy=self.lemmy, report=parsed_result.post_report_view, post=self
+        )


### PR DESCRIPTION
Relates to #16 .

This adds a `skip_existing` parameter to the streams (`False` by default). When turned on, results in the past are ignored, and only future results are returned.

In practice what this means is that the results from the first request are ignored, thereby skipping existing results.

Is this enough for your purposes @noenfugler ?